### PR TITLE
Use NSLogger API to pass the file/line-number/function so that the Viewer Apps can choose to show or hide them.

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - XCGLogger (3.1.1)
 
 DEPENDENCIES:
-  - NSLogger (~> 1.5.0)
+  - NSLogger (~> 1.5)
   - XCGLogger (~> 3.1)
 
 SPEC CHECKSUMS:

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -5,7 +5,7 @@ PODS:
   - XCGLogger (3.1.1)
 
 DEPENDENCIES:
-  - NSLogger (~> 1.5.0)
+  - NSLogger (~> 1.5)
   - XCGLogger (~> 3.1)
 
 SPEC CHECKSUMS:

--- a/XCGLoggerNSLoggerConnector.podspec
+++ b/XCGLoggerNSLoggerConnector.podspec
@@ -20,11 +20,11 @@ Pod::Spec.new do |s|
 #Adds NSLogger support (with images) to XCGLogger.
 #                       DESC
 
-  s.homepage         = "https://github.com/briancordanyoung/XCGLoggerNSLoggerConnector"
+  s.homepage         = "https://github.com/markuswinkler/XCGLoggerNSLoggerConnector"
   # s.screenshots     = "www.example.com/screenshots_1", "www.example.com/screenshots_2"
   s.license = { :type => "MIT", :file => "LICENSE" }
   s.author           = { "Markus Winkler" => "markus@markuswinkler.com" }
-  s.source           = { :git => "https://github.com/briancordanyoung/XCGLoggerNSLoggerConnector.git", :tag => "#{s.version}" }
+  s.source           = { :git => "https://github.com/markuswinkler/XCGLoggerNSLoggerConnector.git", :tag => "#{s.version}" }
   s.social_media_url = 'https://twitter.com/creativegun'
 
   s.platform     = :ios, '8.0'

--- a/XCGLoggerNSLoggerConnector.podspec
+++ b/XCGLoggerNSLoggerConnector.podspec
@@ -20,11 +20,11 @@ Pod::Spec.new do |s|
 #Adds NSLogger support (with images) to XCGLogger.
 #                       DESC
 
-  s.homepage         = "https://github.com/markuswinkler/XCGLoggerNSLoggerConnector"
+  s.homepage         = "https://github.com/briancordanyoung/XCGLoggerNSLoggerConnector"
   # s.screenshots     = "www.example.com/screenshots_1", "www.example.com/screenshots_2"
   s.license = { :type => "MIT", :file => "LICENSE" }
   s.author           = { "Markus Winkler" => "markus@markuswinkler.com" }
-  s.source           = { :git => "https://github.com/markuswinkler/XCGLoggerNSLoggerConnector.git", :tag => "#{s.version}" }
+  s.source           = { :git => "https://github.com/briancordanyoung/XCGLoggerNSLoggerConnector.git", :tag => "#{s.version}" }
   s.social_media_url = 'https://twitter.com/creativegun'
 
   s.platform     = :ios, '8.0'

--- a/XCGLoggerNSLoggerConnector/XCGLoggerNSLoggerConnector.swift
+++ b/XCGLoggerNSLoggerConnector/XCGLoggerNSLoggerConnector.swift
@@ -61,7 +61,6 @@ public class XCGNSLoggerLogDestination: XCGBaseLogDestination {
             fileName = last
         }
 
-//        LogMessage_va(logDetails.logLevel.description, convertLogLevel(logDetails.logLevel), "[\(fileName):\(logDetails.lineNumber)] -> \(logDetails.functionName) : \(logDetails.logMessage)",getVaList([]))
         LogMessageF_va(logDetails.fileName, Int32(logDetails.lineNumber), logDetails.functionName, logDetails.logLevel.description, Int32(convertLogLevel(logDetails.logLevel)), logDetails.logMessage, getVaList([]))
     }
 }
@@ -91,7 +90,7 @@ public extension XCGLogger {
     private func sendImageToNSLogger(image: UIImage?, level: LogLevel, label: String, functionName: String = __FUNCTION__, fileName: String = __FILE__, lineNumber: Int = __LINE__) {
         // check if image is valid, otherwise display error
         if let image: UIImage = image {
-            LogImageData(label, convertLogLevel(level), Int32(image.size.width), Int32(image.size.height), UIImagePNGRepresentation(image))
+            LogImageDataF(fileName, Int32(lineNumber), functionName, label, convertLogLevel(level), Int32(image.size.width), Int32(image.size.height), UIImagePNGRepresentation(image))
             self.logln(level, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: {return "Image: \(image)"})
         }
         else {
@@ -108,8 +107,7 @@ public extension XCGLogger {
         }
         let level = LogLevel.None
         if let image: UIImage = closure() {
-            LogImageData(label, convertLogLevel(level), Int32(image.size.width), Int32(image.size.height), UIImagePNGRepresentation(image))
-//            LogMessage_va(label, convertLogLevel(level), "[\(fileName2):\(lineNumber)] -> \(functionName) : \(image)",getVaList([]))
+            LogImageDataF(fileName, Int32(lineNumber), functionName, label, convertLogLevel(level), Int32(image.size.width), Int32(image.size.height), UIImagePNGRepresentation(image))
             LogMessageF_va(fileName, Int32(lineNumber), functionName, label, Int32(convertLogLevel(level)), "\(image)", getVaList([]))
             self.logln(level, functionName: functionName, fileName: fileName2, lineNumber: lineNumber, closure: {return "Image: \(image)"})
         }
@@ -127,13 +125,11 @@ public extension XCGLogger {
         }
 
         if let message = closure() {
-//            LogMessage_va(label, convertLogLevel(level), "[\(fileName2):\(lineNumber)] -> \(functionName) : \(message)",getVaList([]))
             LogMessageF_va(fileName, Int32(lineNumber), functionName, label, Int32(convertLogLevel(level)), "\(message)", getVaList([]))
             self.logln(level, functionName: functionName, fileName: fileName2, lineNumber: lineNumber, closure: {return "[\(label)] \(message)"})
         }
         else
         {
-//            LogMessage_va(label, convertLogLevel(level), "[\(fileName2):\(lineNumber)] -> \(functionName) : nil",getVaList([]))
             LogMessageF_va(fileName, Int32(lineNumber), functionName, label, Int32(convertLogLevel(level)), "nil", getVaList([]))
             self.logln(level, functionName: functionName, fileName: fileName2, lineNumber: lineNumber, closure: {return "[\(label)] nil"})
         }

--- a/XCGLoggerNSLoggerConnector/XCGLoggerNSLoggerConnector.swift
+++ b/XCGLoggerNSLoggerConnector/XCGLoggerNSLoggerConnector.swift
@@ -61,7 +61,8 @@ public class XCGNSLoggerLogDestination: XCGBaseLogDestination {
             fileName = last
         }
 
-        LogMessage_va(logDetails.logLevel.description, convertLogLevel(logDetails.logLevel), "[\(fileName):\(logDetails.lineNumber)] -> \(logDetails.functionName) : \(logDetails.logMessage)",getVaList([]))
+//        LogMessage_va(logDetails.logLevel.description, convertLogLevel(logDetails.logLevel), "[\(fileName):\(logDetails.lineNumber)] -> \(logDetails.functionName) : \(logDetails.logMessage)",getVaList([]))
+        LogMessageF_va(logDetails.fileName, Int32(logDetails.lineNumber), logDetails.functionName, logDetails.logLevel.description, Int32(convertLogLevel(logDetails.logLevel)), logDetails.logMessage, getVaList([]))
     }
 }
 
@@ -108,7 +109,8 @@ public extension XCGLogger {
         let level = LogLevel.None
         if let image: UIImage = closure() {
             LogImageData(label, convertLogLevel(level), Int32(image.size.width), Int32(image.size.height), UIImagePNGRepresentation(image))
-            LogMessage_va(label, convertLogLevel(level), "[\(fileName2):\(lineNumber)] -> \(functionName) : \(image)",getVaList([]))
+//            LogMessage_va(label, convertLogLevel(level), "[\(fileName2):\(lineNumber)] -> \(functionName) : \(image)",getVaList([]))
+            LogMessageF_va(fileName, Int32(lineNumber), functionName, label, Int32(convertLogLevel(level)), "\(image)", getVaList([]))
             self.logln(level, functionName: functionName, fileName: fileName2, lineNumber: lineNumber, closure: {return "Image: \(image)"})
         }
         else {
@@ -125,12 +127,14 @@ public extension XCGLogger {
         }
 
         if let message = closure() {
-            LogMessage_va(label, convertLogLevel(level), "[\(fileName2):\(lineNumber)] -> \(functionName) : \(message)",getVaList([]))
+//            LogMessage_va(label, convertLogLevel(level), "[\(fileName2):\(lineNumber)] -> \(functionName) : \(message)",getVaList([]))
+            LogMessageF_va(fileName, Int32(lineNumber), functionName, label, Int32(convertLogLevel(level)), "\(message)", getVaList([]))
             self.logln(level, functionName: functionName, fileName: fileName2, lineNumber: lineNumber, closure: {return "[\(label)] \(message)"})
         }
         else
         {
-            LogMessage_va(label, convertLogLevel(level), "[\(fileName2):\(lineNumber)] -> \(functionName) : nil",getVaList([]))
+//            LogMessage_va(label, convertLogLevel(level), "[\(fileName2):\(lineNumber)] -> \(functionName) : nil",getVaList([]))
+            LogMessageF_va(fileName, Int32(lineNumber), functionName, label, Int32(convertLogLevel(level)), "nil", getVaList([]))
             self.logln(level, functionName: functionName, fileName: fileName2, lineNumber: lineNumber, closure: {return "[\(label)] nil"})
         }
     }


### PR DESCRIPTION
I was happy to see that you made XCGLoggerNSLoggerConnector!

I don't know if you have a reason to always include the file, line-number & function name in the log message.  But, NSLogger allows these to be passed so that the viewer apps can choose to show or hide this meta data.  This pull request changes all NSLogger calls to do this.
