### PR TITLE
Remove stray FileDestination declaration

### DIFF
--- a/XCGLoggerNSLoggerConnector/XCGLoggerNSLoggerConnector.swift
+++ b/XCGLoggerNSLoggerConnector/XCGLoggerNSLoggerConnector.swift
@@ -48,7 +48,6 @@ public class XCGNSLoggerLogDestination: BaseDestination {
         case .none:
             return 3
         }
-        let x:FileDestination!
     }
     
 	public init(owner: XCGLogger, identifier: String, addInlineDebugInfo: Bool = false, outputLevel: XCGLogger.Level = .debug) {


### PR DESCRIPTION
## Summary
- remove unused FileDestination declaration from convertLogLevel

## Testing
- `swiftc -c XCGLoggerNSLoggerConnector/XCGLoggerNSLoggerConnector.swift` *(fails: no such module 'XCGLogger')*

------
https://chatgpt.com/codex/tasks/task_e_6896310aef7c8330a4562671d477833e